### PR TITLE
Enable camera frames in URDF

### DIFF
--- a/spot_description/launch/description.launch
+++ b/spot_description/launch/description.launch
@@ -1,5 +1,6 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro $(find spot_description)/urdf/spot.urdf.xacro --inorder" />
+  <arg name="static_camera_frames" default="false"/>
+  <param name="robot_description" command="$(find xacro)/xacro $(find spot_description)/urdf/spot.urdf.xacro --inorder static_camera_frames:=$(arg static_camera_frames) " />
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 </launch>

--- a/spot_description/launch/load.launch
+++ b/spot_description/launch/load.launch
@@ -1,0 +1,4 @@
+<launch>
+  <arg name="static_camera_frames" default="false"/>
+  <param name="robot_description" command="$(find xacro)/xacro $(find spot_description)/urdf/spot.urdf.xacro --inorder static_camera_frames:=$(arg static_camera_frames) " />
+</launch>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <robot name="spot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:arg name="static_camera_frames"  default="false"/>
+
     <link name="body">
         <visual>
             <geometry>
@@ -265,4 +267,84 @@
 
     <!-- Optional custom includes. -->
     <xacro:include filename="$(optenv SPOT_URDF_EXTRAS empty.urdf)" />
+
+    <!-- Include cameras -->
+    <xacro:if value="$(arg static_camera_frames)">
+        <link name="head"/>
+        <joint name="head_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <parent link="body" />
+            <child link="head" />
+        </joint>
+
+        <!-- Back camera -->
+        <link name="back"/>
+        <joint name="back_joint" type="fixed">
+            <origin xyz="-0.417 -0.039 0.009" rpy="-1.832 0.008 1.569" />
+            <parent link="head" />
+            <child link="back" />
+        </joint>
+        <link name="back_fisheye"/>
+        <joint name="back_fisheye_joint" type="fixed">
+            <origin xyz="0.072 -0.004 0.000" rpy="-0.001 -0.005 -0.004" />
+            <parent link="back" />
+            <child link="back_fisheye" />
+        </joint>
+
+        <!-- Front left camera -->
+        <link name="frontleft"/>
+        <joint name="frontleft_joint" type="fixed">
+            <origin xyz="0.414 0.035 0.025" rpy="-2.586 1.142 -3.132" />
+            <parent link="head" />
+            <child link="frontleft" />
+        </joint>
+        <link name="frontleft_fisheye"/>
+        <joint name="frontleft_fisheye_joint" type="fixed">
+            <origin xyz="0.075 -0.003 0.002" rpy="-0.008 -0.009 0.001" />
+            <parent link="frontleft" />
+            <child link="frontleft_fisheye" />
+        </joint>
+
+        <!-- Front right camera -->
+        <link name="frontright"/>
+        <joint name="frontright_joint" type="fixed">
+            <origin xyz="0.415 -0.039 0.024" rpy="2.610 1.147 -3.127" />
+            <parent link="head" />
+            <child link="frontright" />
+        </joint>
+        <link name="frontright_fisheye"/>
+        <joint name="frontright_fisheye_joint" type="fixed">
+            <origin xyz="0.072 -0.005 0.001" rpy="0.000 -0.010 0.010" />
+            <parent link="frontright" />
+            <child link="frontright_fisheye" />
+        </joint>
+
+        <!-- Left camera -->
+        <link name="left"/>
+        <joint name="left_joint" type="fixed">
+            <origin xyz="-0.164 0.109 0.037" rpy="-1.839 0.005 0.006" />
+            <parent link="head" />
+            <child link="left" />
+        </joint>
+        <link name="left_fisheye"/>
+        <joint name="left_fisheye_joint" type="fixed">
+            <origin xyz="0.075 -0.006 0.001" rpy="0.000 -0.007 0.010" />
+            <parent link="left" />
+            <child link="left_fisheye" />
+        </joint>
+
+        <!-- Right camera -->
+        <link name="right"/>
+        <joint name="right_joint" type="fixed">
+            <origin xyz="-0.168 -0.109 0.036" rpy="1.838 -0.005 -0.003" />
+            <parent link="head" />
+            <child link="right" />
+        </joint>
+        <link name="right_fisheye"/>
+        <joint name="right_fisheye_joint" type="fixed">
+            <origin xyz="0.077 -0.007 0.001" rpy="0.004 0.004 0.003" />
+            <parent link="right" />
+            <child link="right_fisheye" />
+        </joint>
+    </xacro:if>
 </robot>

--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -2,8 +2,12 @@
   <arg name="username" default="dummyusername" />
   <arg name="password" default="dummypassword" />
   <arg name="hostname" default="192.168.50.3" />
+  <arg name="static_camera_frames" default="false" />
 
-  <include file="$(find spot_description)/launch/description.launch" />
+  <include file="$(find spot_description)/launch/description.launch">
+    <arg name="static_camera_frames" value="$(arg static_camera_frames)"/>
+  </include>
+  
   <include file="$(find spot_driver)/launch/control.launch" />
 
   <node pkg="spot_driver" type="spot_ros.py" name="spot_ros"  ns="spot" output="screen">
@@ -11,6 +15,7 @@
     <param name="username" value="$(arg username)" />
     <param name="password" value="$(arg password)" />
     <param name="hostname" value="$(arg hostname)" />
+    <param name="static_camera_frames" value="$(arg static_camera_frames)" />
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/spot_driver/scripts/ros_helpers.py
+++ b/spot_driver/scripts/ros_helpers.py
@@ -82,47 +82,49 @@ def getImageMsg(data, spot_wrapper, inverse_target_frame):
     Args:
         data: Image proto
         spot_wrapper: A SpotWrapper object
-        inverse_target_frame: A frame name to be inversed to a parent frame.
+        inverse_target_frame: A frame name to be inversed to a parent frame. If frame provided is None,
+        tf transformation is skipped.
     Returns:
         (tuple):
             * Image: message of the image captured
             * CameraInfo: message to define the state and config of the camera that took the image
             * TFMessage: with the transforms necessary to locate the image frames
     """
-    tf_msg = TFMessage()
-    for frame_name in data.shot.transforms_snapshot.child_to_parent_edge_map:
-        if data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name).parent_frame_name:
-            try:
-                transform = data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
-                new_tf = TransformStamped()
-                local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
-                new_tf.header.stamp = rospy.Time(local_time.seconds, local_time.nanos)
-                parent = transform.parent_frame_name
-                child = frame_name
-                if inverse_target_frame == frame_name:
-                    geo_tform_inversed = SE3Pose.from_obj(transform.parent_tform_child).inverse()
-                    new_tf.header.frame_id = frame_name
-                    new_tf.child_frame_id = transform.parent_frame_name
-                    new_tf.transform.translation.x = geo_tform_inversed.position.x
-                    new_tf.transform.translation.y = geo_tform_inversed.position.y
-                    new_tf.transform.translation.z = geo_tform_inversed.position.z
-                    new_tf.transform.rotation.x = geo_tform_inversed.rotation.x
-                    new_tf.transform.rotation.y = geo_tform_inversed.rotation.y
-                    new_tf.transform.rotation.z = geo_tform_inversed.rotation.z
-                    new_tf.transform.rotation.w = geo_tform_inversed.rotation.w
-                else:
-                    new_tf.header.frame_id = transform.parent_frame_name
-                    new_tf.child_frame_id = frame_name
-                    new_tf.transform.translation.x = transform.parent_tform_child.position.x
-                    new_tf.transform.translation.y = transform.parent_tform_child.position.y
-                    new_tf.transform.translation.z = transform.parent_tform_child.position.z
-                    new_tf.transform.rotation.x = transform.parent_tform_child.rotation.x
-                    new_tf.transform.rotation.y = transform.parent_tform_child.rotation.y
-                    new_tf.transform.rotation.z = transform.parent_tform_child.rotation.z
-                    new_tf.transform.rotation.w = transform.parent_tform_child.rotation.w
-                tf_msg.transforms.append(new_tf)
-            except Exception as e:
-                print('Error: {}'.format(e))
+    if inverse_target_frame:
+        tf_msg = TFMessage()
+        for frame_name in data.shot.transforms_snapshot.child_to_parent_edge_map:
+            if data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name).parent_frame_name:
+                try:
+                    transform = data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
+                    new_tf = TransformStamped()
+                    local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
+                    new_tf.header.stamp = rospy.Time(local_time.seconds, local_time.nanos)
+                    parent = transform.parent_frame_name
+                    child = frame_name
+                    if inverse_target_frame == frame_name:
+                        geo_tform_inversed = SE3Pose.from_obj(transform.parent_tform_child).inverse()
+                        new_tf.header.frame_id = frame_name
+                        new_tf.child_frame_id = transform.parent_frame_name
+                        new_tf.transform.translation.x = geo_tform_inversed.position.x
+                        new_tf.transform.translation.y = geo_tform_inversed.position.y
+                        new_tf.transform.translation.z = geo_tform_inversed.position.z
+                        new_tf.transform.rotation.x = geo_tform_inversed.rotation.x
+                        new_tf.transform.rotation.y = geo_tform_inversed.rotation.y
+                        new_tf.transform.rotation.z = geo_tform_inversed.rotation.z
+                        new_tf.transform.rotation.w = geo_tform_inversed.rotation.w
+                    else:
+                        new_tf.header.frame_id = transform.parent_frame_name
+                        new_tf.child_frame_id = frame_name
+                        new_tf.transform.translation.x = transform.parent_tform_child.position.x
+                        new_tf.transform.translation.y = transform.parent_tform_child.position.y
+                        new_tf.transform.translation.z = transform.parent_tform_child.position.z
+                        new_tf.transform.rotation.x = transform.parent_tform_child.rotation.x
+                        new_tf.transform.rotation.y = transform.parent_tform_child.rotation.y
+                        new_tf.transform.rotation.z = transform.parent_tform_child.rotation.z
+                        new_tf.transform.rotation.w = transform.parent_tform_child.rotation.w
+                    tf_msg.transforms.append(new_tf)
+                except Exception as e:
+                    print('Error: {}'.format(e))
 
     image_msg = Image()
     local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)

--- a/spot_driver/scripts/ros_helpers.py
+++ b/spot_driver/scripts/ros_helpers.py
@@ -90,8 +90,8 @@ def getImageMsg(data, spot_wrapper, inverse_target_frame):
             * CameraInfo: message to define the state and config of the camera that took the image
             * TFMessage: with the transforms necessary to locate the image frames
     """
+    tf_msg = TFMessage()
     if inverse_target_frame:
-        tf_msg = TFMessage()
         for frame_name in data.shot.transforms_snapshot.child_to_parent_edge_map:
             if data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name).parent_frame_name:
                 try:

--- a/spot_driver/scripts/spot_ros.py
+++ b/spot_driver/scripts/spot_ros.py
@@ -161,19 +161,19 @@ class SpotROS():
             image_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, self.mode_parent_odom_tf)
             self.frontleft_image_pub.publish(image_msg0)
             self.frontleft_image_info_pub.publish(camera_info_msg0)
-            self.tf_pub.publish(camera_tf_msg0)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg0)
             image_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, self.mode_parent_odom_tf)
             self.frontright_image_pub.publish(image_msg1)
             self.frontright_image_info_pub.publish(camera_info_msg1)
-            self.tf_pub.publish(camera_tf_msg1)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg1)
             image_msg2, camera_info_msg2, camera_tf_msg2 = getImageMsg(data[2], self.spot_wrapper, self.mode_parent_odom_tf)
             self.frontleft_depth_pub.publish(image_msg2)
             self.frontleft_depth_info_pub.publish(camera_info_msg2)
-            self.tf_pub.publish(camera_tf_msg2)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg2)
             image_msg3, camera_info_msg3, camera_tf_msg3 = getImageMsg(data[3], self.spot_wrapper, self.mode_parent_odom_tf)
             self.frontright_depth_pub.publish(image_msg3)
             self.frontright_depth_info_pub.publish(camera_info_msg3)
-            self.tf_pub.publish(camera_tf_msg3)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg3)
 
     def SideImageCB(self, results):
         """Callback for when the Spot Wrapper gets new side image data.
@@ -186,19 +186,19 @@ class SpotROS():
             image_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, self.mode_parent_odom_tf)
             self.left_image_pub.publish(image_msg0)
             self.left_image_info_pub.publish(camera_info_msg0)
-            self.tf_pub.publish(camera_tf_msg0)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg0)
             image_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, self.mode_parent_odom_tf)
             self.right_image_pub.publish(image_msg1)
             self.right_image_info_pub.publish(camera_info_msg1)
-            self.tf_pub.publish(camera_tf_msg1)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg1)
             image_msg2, camera_info_msg2, camera_tf_msg2 = getImageMsg(data[2], self.spot_wrapper, self.mode_parent_odom_tf)
             self.left_depth_pub.publish(image_msg2)
             self.left_depth_info_pub.publish(camera_info_msg2)
-            self.tf_pub.publish(camera_tf_msg2)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg2)
             image_msg3, camera_info_msg3, camera_tf_msg3 = getImageMsg(data[3], self.spot_wrapper, self.mode_parent_odom_tf)
             self.right_depth_pub.publish(image_msg3)
             self.right_depth_info_pub.publish(camera_info_msg3)
-            self.tf_pub.publish(camera_tf_msg3)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg3)
 
     def RearImageCB(self, results):
         """Callback for when the Spot Wrapper gets new rear image data.
@@ -211,11 +211,11 @@ class SpotROS():
             mage_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, self.mode_parent_odom_tf)
             self.back_image_pub.publish(mage_msg0)
             self.back_image_info_pub.publish(camera_info_msg0)
-            self.tf_pub.publish(camera_tf_msg0)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg0)
             mage_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, self.mode_parent_odom_tf)
             self.back_depth_pub.publish(mage_msg1)
             self.back_depth_info_pub.publish(camera_info_msg1)
-            self.tf_pub.publish(camera_tf_msg1)
+            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg1)
 
     def handle_claim(self, req):
         """ROS service handler for the claim service"""
@@ -297,6 +297,7 @@ class SpotROS():
         self.username = rospy.get_param('~username', 'default_value')
         self.password = rospy.get_param('~password', 'default_value')
         self.hostname = rospy.get_param('~hostname', 'default_value')
+        self.static_camera_frames = rospy.get_param('~static_camera_frames', 'default_value')
         self.motion_deadzone = rospy.get_param('~deadzone', 0.05)
 
         # Spot has 2 types of odometries: 'odom' and 'vision'

--- a/spot_driver/scripts/spot_ros.py
+++ b/spot_driver/scripts/spot_ros.py
@@ -158,22 +158,27 @@ class SpotROS():
         """
         data = self.spot_wrapper.front_images
         if data:
-            image_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, self.mode_parent_odom_tf)
+            frame = None if self.static_camera_frames else self.mode_parent_odom_tf
+            image_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, frame)
             self.frontleft_image_pub.publish(image_msg0)
             self.frontleft_image_info_pub.publish(camera_info_msg0)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg0)
-            image_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg0)
+            image_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, frame)
             self.frontright_image_pub.publish(image_msg1)
             self.frontright_image_info_pub.publish(camera_info_msg1)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg1)
-            image_msg2, camera_info_msg2, camera_tf_msg2 = getImageMsg(data[2], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg1)
+            image_msg2, camera_info_msg2, camera_tf_msg2 = getImageMsg(data[2], self.spot_wrapper, frame)
             self.frontleft_depth_pub.publish(image_msg2)
             self.frontleft_depth_info_pub.publish(camera_info_msg2)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg2)
-            image_msg3, camera_info_msg3, camera_tf_msg3 = getImageMsg(data[3], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg2)
+            image_msg3, camera_info_msg3, camera_tf_msg3 = getImageMsg(data[3], self.spot_wrapper, frame)
             self.frontright_depth_pub.publish(image_msg3)
             self.frontright_depth_info_pub.publish(camera_info_msg3)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg3)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg3)
 
     def SideImageCB(self, results):
         """Callback for when the Spot Wrapper gets new side image data.
@@ -183,22 +188,27 @@ class SpotROS():
         """
         data = self.spot_wrapper.side_images
         if data:
-            image_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, self.mode_parent_odom_tf)
+            frame = None if self.static_camera_frames else self.mode_parent_odom_tf
+            image_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, frame)
             self.left_image_pub.publish(image_msg0)
             self.left_image_info_pub.publish(camera_info_msg0)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg0)
-            image_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg0)
+            image_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, frame)
             self.right_image_pub.publish(image_msg1)
             self.right_image_info_pub.publish(camera_info_msg1)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg1)
-            image_msg2, camera_info_msg2, camera_tf_msg2 = getImageMsg(data[2], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg1)
+            image_msg2, camera_info_msg2, camera_tf_msg2 = getImageMsg(data[2], self.spot_wrapper, frame)
             self.left_depth_pub.publish(image_msg2)
             self.left_depth_info_pub.publish(camera_info_msg2)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg2)
-            image_msg3, camera_info_msg3, camera_tf_msg3 = getImageMsg(data[3], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg2)
+            image_msg3, camera_info_msg3, camera_tf_msg3 = getImageMsg(data[3], self.spot_wrapper, frame)
             self.right_depth_pub.publish(image_msg3)
             self.right_depth_info_pub.publish(camera_info_msg3)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg3)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg3)
 
     def RearImageCB(self, results):
         """Callback for when the Spot Wrapper gets new rear image data.
@@ -208,14 +218,17 @@ class SpotROS():
         """
         data = self.spot_wrapper.rear_images
         if data:
-            mage_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, self.mode_parent_odom_tf)
+            frame = None if self.static_camera_frames else self.mode_parent_odom_tf
+            mage_msg0, camera_info_msg0, camera_tf_msg0 = getImageMsg(data[0], self.spot_wrapper, frame)
             self.back_image_pub.publish(mage_msg0)
             self.back_image_info_pub.publish(camera_info_msg0)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg0)
-            mage_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, self.mode_parent_odom_tf)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg0)
+            mage_msg1, camera_info_msg1, camera_tf_msg1 = getImageMsg(data[1], self.spot_wrapper, frame)
             self.back_depth_pub.publish(mage_msg1)
             self.back_depth_info_pub.publish(camera_info_msg1)
-            if self.static_camera_frames: self.tf_pub.publish(camera_tf_msg1)
+            if not self.static_camera_frames:
+                self.tf_pub.publish(camera_tf_msg1)
 
     def handle_claim(self, req):
         """ROS service handler for the claim service"""

--- a/spot_viz/launch/view_model.launch
+++ b/spot_viz/launch/view_model.launch
@@ -1,5 +1,8 @@
 <launch>
-  <include file="$(find spot_description)/launch/description.launch"/>
+  <arg name="static_camera_frames" default="false" />
+  <include file="$(find spot_description)/launch/description.launch">
+    <arg name="static_camera_frames" value="$(arg static_camera_frames)"/>
+  </include>
 
   <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
 


### PR DESCRIPTION
This PR adds the camera frames as fixed frames in the xacro files.
Since Spot actually publishes the TFs for the cameras (but at frame rate, as part of the camera publication), we obtained the fixed transformations from a rosbag and confirmed they didn't change over time.

The changes include:
- A flag `static_camera_frames` was added to the xacro, which can enable this feature
- The launchfiles were updated accordingly to support this flag:
  - `spot_description/launch/description.launch`
  - `spot_driver/launch/driver.launch`
  - `spot_viz/launch/view_model.launch`
- The driver `spot_driver/scripts/spot_ros.py` also was modified to disable the publication of TF at frame rate when the flag is enabled.
- Lastly, I also added `spot_description/launch/load.launch` to load the model into the parameter server, which is useful when using rosbags.

I tested the flag using `view_model.launch`, and also lauching the driver in my laptop and checking that the static transforms were being published when the flag was enabled (even when Spot was not connected).

@heuristicus Please test it as we discussed today. Tell me if you need me to modify anything or feel free to do it if it's easier.

**Flag disabled:**
![rviz_spot_flag_disabled](https://user-images.githubusercontent.com/3932927/102127362-52a25280-3e44-11eb-843c-249900090534.png)

**Flag enabled:**
![rviz_spot_flag_enabled](https://user-images.githubusercontent.com/3932927/102127381-57ff9d00-3e44-11eb-9ced-64f151147504.png)