### PR TITLE
Remove redundant ouster urdf

### DIFF
--- a/spot_description/urdf/ouster.urdf.xacro
+++ b/spot_description/urdf/ouster.urdf.xacro
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<robot name="os" xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:include filename="$(find rooster_description)/urdf/ouster.urdf.xacro"/>
-    <!-- add OS Ouster Lidar sensor -->
-    <xacro:os_device name="os1_sensor" parent="front_rail" simulation="false">
-      <origin xyz="0.07 0 0.03" rpy="0 0 0" />
-    </xacro:os_device>
-</robot>


### PR DESCRIPTION
We appear to be using the more up to date `ouster_extension.urdf.xacro` in `spot_runtime_drs`. This file is not used, and also outdated (uses `rooster_description` instead of `ouster_description` and `os1` instead of `os`)

@heuristicus for review
@mcamurri fyi